### PR TITLE
add orders queue and associated configuration

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -9,6 +9,7 @@ param appServiceAppName string = 'toylaunch${uniqueString(resourceGroup().id)}'
 param environmentType string
 
 var storageAccountSkuName = (environmentType == 'prod') ? 'Standard_GRS' : 'Standard_LRS'
+var processOrderQueueName = 'processorder'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   name: storageAccountName
@@ -20,6 +21,13 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
   properties: {
     accessTier: 'Hot'
   }
+  resource queueServices 'queueServices' existing = {
+    name: 'default'
+
+    resource processOrderQueue 'queues' = {
+      name: processOrderQueueName
+    }
+  }
 }
 
 module appService 'modules/appService.bicep' = {
@@ -27,6 +35,8 @@ module appService 'modules/appService.bicep' = {
   params: {
     location: location
     appServiceAppName: appServiceAppName
+    storageAccountName: storageAccount.name
+    processOrderQueueName: storageAccount::queueServices::processOrderQueue.name
     environmentType: environmentType
   }
 }

--- a/deploy/modules/appService.bicep
+++ b/deploy/modules/appService.bicep
@@ -1,5 +1,7 @@
 param location string
 param appServiceAppName string
+param storageAccountName string
+param processOrderQueueName string
 
 @allowed([
   'nonprod'
@@ -24,6 +26,18 @@ resource appServiceApp 'Microsoft.Web/sites@2020-06-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'StorageAccountName'
+          value: storageAccountName
+        }
+        {
+          name: 'ProcessOrderQueueName'
+          value: processOrderQueueName
+        }
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a new Azure Storage queue for processing orders, and updates the website configuration to include the storage account and queue information.